### PR TITLE
Copy almalinux-8 into manylinux_2_28

### DIFF
--- a/.github/workflows/create_manylinux_2_28_gstlearn-r.yml
+++ b/.github/workflows/create_manylinux_2_28_gstlearn-r.yml
@@ -1,0 +1,25 @@
+name: manylinux_2_28 for gstlearn-based R software
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Manual'
+        required: false
+        default: ''
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and push manylinux_2_28-swigex0-r docker
+        working-directory: .
+        run: |
+          docker build -t ${{env.USER}}/manylinux_2_28-gstlearn-r -f manylinux/2_28/Dockerfile_gstlearn_r .
+          docker login -u ${{env.USER}} -p ${{env.TOKEN}}
+          docker push ${{env.USER}}/manylinux_2_28-gstlearn-r
+          docker logout
+        env:
+          USER: ${{ secrets.DOCKER_HUB_USERNAME }}
+          TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/manylinux/2_28/Dockerfile_gstlearn_r
+++ b/manylinux/2_28/Dockerfile_gstlearn_r
@@ -1,0 +1,42 @@
+FROM fabienors/manylinux_2_28-swigex0-r
+
+# Install recent Boost HEADER header files
+# ==============================================================
+RUN wget https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz && \
+    tar -xvzf boost_1_88_0.tar.gz && \
+    cd boost_1_88_0 && \
+    ./bootstrap.sh --prefix=/usr/local --with-libraries=all && \
+    ./b2 cxxflags="-fPIC" cflags="-fPIC" link=static runtime-link=shared install -j$(nproc) && \
+    cd .. && \
+    rm -rf boost_1_88_0*
+
+# Install recent nlopt header files
+# ==============================================================
+RUN wget https://github.com/stevengj/nlopt/archive/v2.10.0.tar.gz && \
+    tar -xvzf v2.10.0.tar.gz && \
+    cd nlopt-2.10.0 && \
+    mkdir build && cd build && \
+    cmake -DBUILD_SHARED_LIBS=OFF -DNLOPT_GUILE=OFF -DNLOPT_MATLAB=OFF -DNLOPT_OCTAVE=OFF -DNLOPT_PYTHON=OFF -DNLOPT_SWIG=OFF -DNLOPT_TESTS=OFF .. && \
+    cmake --build . --parallel 3 && \
+    cmake --build . --target install
+
+# Install recent Eigen3 header files
+# ==============================================================
+RUN wget https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz && \
+    tar -xvzf eigen-3.4.0.tar.gz && \
+    cd eigen-3.4.0 && \
+    mkdir build && cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    make install && \
+    cd ../.. && \
+    rm -rf eigen-3.4.0*
+
+# Install recent HDF5 lib
+# ==============================================================
+RUN wget https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz && \
+    tar -xvzf hdf5-1.14.6.tar.gz && \
+    cd hdf5-1.14.6 && \
+    mkdir build && cd build && \
+    cmake -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DHDF5_BUILD_EXAMPLES=OFF -DHDF5_BUILD_HL_LIB=OFF -DHDF5_BUILD_CPP_LIB=ON -DHDF_PACKAGE_NAMESPACE=hdf5:: -DHDF5_INSTALL_MOD_FORTRAN=NO -DHDF5_BUILD_GENERATORS=ON -DHDF5_ENABLE_ALL_WARNINGS=ON -DHDF5_MINGW_STATIC_GCC_LIBS=ON -DHDF5_ALLOW_EXTERNAL_SUPPORT=TGZ -DTGZPATH=../temp -DZLIB_PACKAGE_NAME=zlib -DZLIB_TGZ_ORIGPATH=https://github.com/madler/zlib/releases/download/v1.3.1 -DZLIB_TGZ_NAME=zlib-1.3.1.tar.gz -DLIBAEC_PACKAGE_NAME=libaec -DLIBAEC_TGZ_ORIGPATH=https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.3 -DLIBAEC_TGZ_NAME=libaec-1.1.3.tar.gz -DHDF5_PACKAGE_EXTLIBS=ON -DHDF5_USE_ZLIB_NG=OFF -DZLIB_USE_LOCALCONTENT=OFF -DLIBAEC_USE_LOCALCONTENT=OFF -DHDF5_USE_ZLIB_STATIC=ON -DHDF5_USE_LIBAEC_STATIC=ON .. && \
+    cmake --build . --parallel 3 && \
+    cmake --build . --target install


### PR DESCRIPTION
Following https://github.com/fabien-ors/docker-generate/pull/1, this PR copies the `almalinux-8` container into `manylinux_2_28`, this time based on `manylinux_2_28-swigex-r`.

Pierre